### PR TITLE
Add feature to override servers when mocking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,11 @@ ARGUMENTS
   DEFINITION  input definition file
 
 OPTIONS
-  -U, --swagger-ui=docs  Swagger UI endpoint
-  -h, --help             show CLI help
-  -p, --port=9000        [default: 9000] port
-  --[no-]logger          [default: true] log requests
+  -U, --swagger-ui=docs                       Swagger UI endpoint
+  -h, --help                                  show CLI help
+  -p, --port=9000                             [default: 9000] port
+  -s, --serveroverride=http://localhost:9000  override servers definition
+  --[no-]logger                               [default: true] log requests
 
 EXAMPLES
   $ openapi mock ./openapi.yml

--- a/src/commands/mock.ts
+++ b/src/commands/mock.ts
@@ -20,7 +20,7 @@ export default class Mock extends Command {
   public static flags = {
     ...commonFlags.help(),
     ...commonFlags.serverOpts(),
-    ...commonFlags.servers(),
+    ...commonFlags.overrideServers(),
     'swagger-ui': flags.string({ char: 'U', description: 'Swagger UI endpoint', helpValue: 'docs' }),
   };
 
@@ -33,7 +33,7 @@ export default class Mock extends Command {
 
   public async run() {
     const { args, flags } = this.parse(Mock);
-    const { port, logger, 'swagger-ui': swaggerui, server } = flags;
+    const { port, logger, 'swagger-ui': swaggerui, serveroverride } = flags;
     const definition = resolveDefinition(args.definition);
     if (!definition) {
       this.error('Please load a definition file', { exit: 1 });
@@ -61,14 +61,13 @@ export default class Mock extends Command {
     app.use(bodyparser());
     app.use(cors({ credentials: true }));
 
-    const docServers =
-      server && server.length > 0
-        ? server.map((server) => ({ url: server }))
-        : [
-            {
-              url: `http://localhost:${port}`,
-            },
-          ];
+    const docServers = serveroverride
+      ? serveroverride.map((url) => ({ url }))
+      : [
+          {
+            url: `http://localhost:${port}`,
+          },
+        ];
 
     // serve openapi.json
     const openApiFile = 'openapi.json';

--- a/src/commands/mock.ts
+++ b/src/commands/mock.ts
@@ -20,6 +20,7 @@ export default class Mock extends Command {
   public static flags = {
     ...commonFlags.help(),
     ...commonFlags.serverOpts(),
+    ...commonFlags.servers(),
     'swagger-ui': flags.string({ char: 'U', description: 'Swagger UI endpoint', helpValue: 'docs' }),
   };
 
@@ -32,8 +33,7 @@ export default class Mock extends Command {
 
   public async run() {
     const { args, flags } = this.parse(Mock);
-    const { port, logger, 'swagger-ui': swaggerui } = flags;
-
+    const { port, logger, 'swagger-ui': swaggerui, server } = flags;
     const definition = resolveDefinition(args.definition);
     if (!definition) {
       this.error('Please load a definition file', { exit: 1 });
@@ -61,6 +61,15 @@ export default class Mock extends Command {
     app.use(bodyparser());
     app.use(cors({ credentials: true }));
 
+    const docServers =
+      server && server.length > 0
+        ? server.map((server) => ({ url: server }))
+        : [
+            {
+              url: `http://localhost:${port}`,
+            },
+          ];
+
     // serve openapi.json
     const openApiFile = 'openapi.json';
     const documentPath = `/${openApiFile}`;
@@ -68,11 +77,7 @@ export default class Mock extends Command {
       mount(documentPath, async (ctx, next) => {
         await next();
         const doc = api.document;
-        doc.servers = [
-          {
-            url: `http://localhost:${port}`,
-          },
-        ];
+        doc.servers = docServers;
         ctx.body = api.document;
         ctx.status = 200;
       }),

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -14,6 +14,15 @@ export const servers = () => ({
   }),
 });
 
+export const overrideServers = () => ({
+  serveroverride: flags.string({
+    char: 's',
+    description: 'override servers definition',
+    helpValue: 'http://localhost:9000',
+    multiple: true,
+  }),
+});
+
 export const validate = () => ({
   validate: flags.boolean({ char: 'V', description: 'validate against openapi schema' }),
 });


### PR DESCRIPTION
This adds -S flag also for `mock` command. This makes it possible to override `servers` for the mocked OpenAPI JSON.

This might come handy when using `mock` for example during testing.