### PR TITLE
Implement remove unreferenced components flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -V, --validate                                                validate against openapi schema
@@ -112,6 +113,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -V, --validate                                                validate against openapi schema
@@ -211,6 +213,7 @@ USAGE
 FLAGS
   -I, --inject={"info":{"version":"1.0.0"}}...  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -S, --server=http://localhost:9000...         override servers definition
   -T, --title=<value>                           [default: My API] The title for the API
   -d, --description=<value>                     Description for the API
@@ -278,6 +281,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -U, --swagger-ui=docs                                         Swagger UI endpoint
@@ -317,6 +321,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -V, --validate                                                validate against openapi schema
@@ -356,6 +361,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -h, --help                                                    Show CLI help.
@@ -423,6 +429,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -h, --help                                                    Show CLI help.
@@ -472,6 +479,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -V, --validate                                                validate against openapi schema
@@ -507,6 +515,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -V, --validate                                                validate against openapi schema
@@ -552,6 +561,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -V, --validate                                                validate against openapi schema
@@ -601,6 +611,7 @@ FLAGS
   -H, --header=<value>...                                       add request headers when calling remote urls
   -I, --inject={"info":{"version":"1.0.0"}}...                  inject JSON to definition with deep merge
   -E, --exclude-ext=x-internal                                  Specify an openapi extension to exclude parts of the spec
+  -U, --remove-unreferenced                                     Remove unreferenced components, you can skip individual component being removed by setting `x-openapicmd-keep` to true
   -R, --root=/                                                  override API root path
   -S, --server=http://localhost:9000...                         override servers definition
   -V, --validate                                                validate against openapi schema

--- a/__tests__/resources/openapi-with-internal.yml
+++ b/__tests__/resources/openapi-with-internal.yml
@@ -43,6 +43,13 @@ components:
         name:
           type: string
           example: Odie
+    PetInput:
+      type: object
+      x-openapicmd-keep: true
+      properties:
+        name:
+          type: string
+          example: Odie
   responses:
     ListPetsRes:
       description: ok

--- a/__tests__/resources/openapi-without-internal-and-unreferenced-components.yml
+++ b/__tests__/resources/openapi-without-internal-and-unreferenced-components.yml
@@ -32,14 +32,6 @@ components:
           type: string
           example: Odie
   responses:
-    ListPetsRes:
-      description: ok
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/Pet'
     PetRes:
       description: ok
       content:

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -9,3 +9,4 @@ export const resourcePath = (...subpath: string[]) => {
 export const testDefinition = YAML.load(fs.readFileSync(resourcePath('openapi.yml')).toString());
 export const testDefinitionBroken = YAML.load(fs.readFileSync(resourcePath('openapi-broken.yml')).toString());
 export const testDefinitionWithoutInternal = YAML.load(fs.readFileSync(resourcePath('openapi-without-internal.yml')).toString());
+export const testDefinitionWithoutInternalAndUnreferenced = YAML.load(fs.readFileSync(resourcePath('openapi-without-internal-and-unreferenced-components.yml')).toString());

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -72,6 +72,7 @@ export class Call extends Command {
         inject: flags.inject,
         strip: flags.strip,
         excludeExt: flags?.['exclude-ext'],
+        removeUnreferenced: flags?.['remove-unreferenced'],
         header,
         induceServers: true,
       });

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -46,6 +46,7 @@ export class Info extends Command {
         servers: flags.server,
         inject: flags.inject,
         excludeExt: flags?.['exclude-ext'],
+        removeUnreferenced: flags?.['remove-unreferenced'],
         header,
       });
     } catch (err) {

--- a/src/commands/mock.ts
+++ b/src/commands/mock.ts
@@ -59,6 +59,7 @@ export class Mock extends Command {
         inject: flags.inject,
         strip: flags.strip,
         excludeExt: flags?.['exclude-ext'],
+        removeUnreferenced: flags?.['remove-unreferenced'],
         header,
         root,
         induceServers: true,

--- a/src/commands/read.test.ts
+++ b/src/commands/read.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@oclif/test';
-import { resourcePath, testDefinition, testDefinitionWithoutInternal } from '../__tests__/test-utils';
+import { resourcePath, testDefinition, testDefinitionWithoutInternal, testDefinitionWithoutInternalAndUnreferenced } from '../__tests__/test-utils';
 import * as SwaggerParser from '@apidevtools/swagger-parser';
 import * as YAML from 'js-yaml';
 import 'chai';
@@ -21,6 +21,15 @@ describe('read', () => {
         const output = YAML.load(ctx.stdout);
         expect(output).to.deep.equal(testDefinitionWithoutInternal);
       });
+
+
+    test
+    .stdout()
+    .command(['read', resourcePath('openapi-with-internal.yml'), '--exclude-ext', 'x-internal', '--remove-unreferenced'])
+    .it('reads yaml openapi spec exluding operations and resources with x-internal and also remove unreferenced components', (ctx) => {
+      const output = YAML.load(ctx.stdout);
+      expect(output).to.deep.equal(testDefinitionWithoutInternalAndUnreferenced);
+    });
 
     test
       .stdout()

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -42,6 +42,7 @@ export class Read extends Command {
         inject: flags.inject,
         strip: flags.strip,
         excludeExt: flags?.['exclude-ext'],
+        removeUnreferenced: flags?.['remove-unreferenced'],
         servers: flags.server,
         header,
         root,

--- a/src/commands/redoc.ts
+++ b/src/commands/redoc.ts
@@ -65,6 +65,7 @@ export class Redoc extends Command {
           servers: flags.server,
           inject: flags.inject,
           excludeExt: flags?.['exclude-ext'],
+          removeUnreferenced: flags?.['remove-unreferenced'],
           strip: flags.strip,
           header,
           root,

--- a/src/commands/swagger-ui.ts
+++ b/src/commands/swagger-ui.ts
@@ -77,6 +77,7 @@ export class SwaggerUI extends Command {
           inject: flags.inject,
           strip: flags.strip,
           excludeExt: flags?.['exclude-ext'],
+          removeUnreferenced: flags?.['remove-unreferenced'],
           header,
           root,
          });

--- a/src/commands/typegen.ts
+++ b/src/commands/typegen.ts
@@ -40,6 +40,7 @@ export class Typegen extends Command {
         validate,
         inject: flags.inject,
         excludeExt: flags?.['exclude-ext'],
+        removeUnreferenced: flags?.['remove-unreferenced'],
         strip: flags.strip,
         servers: flags.server,
         header,

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -40,6 +40,15 @@ export const excludeExt = () => ({
   }),
 });
 
+export const removeUnreferencedComponents = () => ({
+  'remove-unreferenced': Flags.boolean({
+    char: 'U',
+    description: 'Remove unreferenced components, you can skip individual component being removed by setting x-openapicmd-keep to true',
+    default: false,
+    allowNo: true,
+  }),
+});
+
 export const strip = () => ({
   strip: Flags.string({
     char: 'C',
@@ -70,6 +79,7 @@ export const parseOpts = () => ({
   ...inject(),
   ...excludeExt(),
   ...strip(),
+  ...removeUnreferencedComponents(),
 });
 
 export const serverOpts = () => ({


### PR DESCRIPTION
In this PR, I have added a new flag (`--remove-unreferenced`) to optionally control the removal of unreferenced components from the openapi spec. Also we could skip the removal of individual unreferenced component from the openapi spec by adding a setting `x-openapicmd-keep` to be `true` .

OpenAPI spec with some internal endpoints which should be filtered out for public and the unreferenced components which should be removed and some which should be persisted.

```
openapi: 3.0.1
info:
  title: My API
  version: 1.0.0
paths:
  /pets:
    get:
      operationId: getPets
      x-internal: true
      responses:
        '200':
          $ref: '#/components/responses/ListPetsRes'
    post:
      operationId: createPet
      requestBody:
        description: Pet object to create
        content:
          application/json: {}
      responses:
        '201':
          $ref: '#/components/responses/PetRes'
  '/pets/{id}':
    get:
      operationId: getPetById
      responses:
        '200':
          $ref: '#/components/responses/PetRes'
      parameters:
      - name: id
        in: path
        required: true
        schema:
          type: integer
      x-internal: true
components:
  schemas:
    Pet:
      type: object
      properties:
        id:
          type: integer
          minimum: 1
        name:
          type: string
          example: Odie
    PetInput:
      type: object
      x-openapicmd-keep: true
      properties:
        name:
          type: string
          example: Odie
  responses:
    ListPetsRes:
      description: ok
      content:
        application/json:
          schema:
            type: array
            items:
              $ref: '#/components/schemas/Pet'
    PetRes:
      description: ok
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/Pet'
  securitySchemes:
    ApiKeyHeaderAuth:
      type: apiKey
      in: header
      name: x-apikey
      description: API key sent as a header
    BasicAuth:
      type: http
      scheme: basic
      description: Basic username/password authentication sent in Authorization header
    BearerAuth:
      type: http
      scheme: bearer
      description: Bearer token sent in Authorization header
    ApiKeyCookieAuth:
      type: apiKey
      in: cookie
      name: apikey
      description: API key sent as a cookie
    ApiKeyQueryAuth:
      type: apiKey
      in: query
      name: apikey
      description: API key sent as a query parameter
security:
  - BasicAuth: []
  - BearerAuth: []
  - ApiKeyHeaderAuth: []
  - ApiKeyCookieAuth: []
  - ApiKeyQueryAuth: []
```

**Command** - 
``` 
npx openapicmd read --yaml openapi-with-internal.yml --exclude-ext x-internal  --remove-unreferenced > openapi-without-internal.yml
```

**Output**

```
openapi: 3.0.1
info:
  title: My API
  version: 1.0.0
paths:
  /pets:
    post:
      operationId: createPet
      requestBody:
        description: Pet object to create
        content:
          application/json: {}
      responses:
        '201':
          $ref: '#/components/responses/PetRes'
components:
  schemas:
    Pet:
      type: object
      properties:
        id:
          type: integer
          minimum: 1
        name:
          type: string
          example: Odie
    PetInput:
      type: object
      x-openapicmd-keep: true
      properties:
        name:
          type: string
          example: Odie
  responses:
    PetRes:
      description: ok
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/Pet'
  securitySchemes:
    ApiKeyHeaderAuth:
      type: apiKey
      in: header
      name: x-apikey
      description: API key sent as a header
    BasicAuth:
      type: http
      scheme: basic
      description: Basic username/password authentication sent in Authorization header
    BearerAuth:
      type: http
      scheme: bearer
      description: Bearer token sent in Authorization header
    ApiKeyCookieAuth:
      type: apiKey
      in: cookie
      name: apikey
      description: API key sent as a cookie
    ApiKeyQueryAuth:
      type: apiKey
      in: query
      name: apikey
      description: API key sent as a query parameter
security:
- BasicAuth: []
- BearerAuth: []
- ApiKeyHeaderAuth: []
- ApiKeyCookieAuth: []
- ApiKeyQueryAuth: []
```
