### PR TITLE
add remove function for top level path description and summary

### DIFF
--- a/src/common/strip-definition.test.ts
+++ b/src/common/strip-definition.test.ts
@@ -94,6 +94,43 @@ describe('stripDefinition', () => {
       expect(output.info).not.toHaveProperty('description');
     })
 
+    it('should remove descriptions and summaries from path', () => {
+      //given
+      const document = testFixtures.createDefinition({
+        paths: {
+          '/path1': {
+            description: 'description',
+            post: testFixtures.createOperation({
+              requestBody: testFixtures.createRequestBody({
+                description: 'description',
+              }),
+            }),
+          },
+          '/path2': {
+            description: 'description',
+            summary: 'summary',
+            put: testFixtures.createOperation({
+              requestBody: testFixtures.createRequestBody({
+                description: 'description',
+              })
+            }),
+          },
+        },
+      })
+
+      // when
+      const output = stripDefinition(document, { removeDescriptions: true });
+
+      // then
+      expect(output.paths['/path1']).not.toHaveProperty('description');
+      expect(output.paths['/path1']).not.toHaveProperty('summary');
+      expect(output.paths['/path2']).not.toHaveProperty('description');
+      expect(output.paths['/path2']).not.toHaveProperty('summary');
+
+      expect(output.paths['/path1']).toHaveProperty('post');
+      expect(output.paths['/path2']).toHaveProperty('put');
+    })
+
     it('should remove descriptions and summaries from operations', () => {
       // given
       const document = testFixtures.createDefinition({

--- a/src/common/strip-definition.ts
+++ b/src/common/strip-definition.ts
@@ -287,6 +287,9 @@ export const stripDefinition = (document: Definition, options: StripOptions & { 
     // remove descriptions and summaries from operations
     for (const path in output.paths) {
       if (output.paths[path]) {
+        delete output.paths[path].description
+        delete output.paths[path].summary
+        
         // remove descriptions from path level servers
         if (output.paths[path].servers) {
           removeDescriptions(output.paths[path].servers)


### PR DESCRIPTION
## Description
The openapicmd failed to strip when the path has a top level description.
Bellow my OpenapiSpec File with a top level path desrciption and the error i get when running the following:
```bash
npx openapicmd read --strip openapi_client_axios --format json src....
```

**Yaml OpenapiSpec**
```yaml
paths:
  /sidemenu:
    description: Path to load side menu entries.
    get:
      description: Returns a list of side menu entries.
      tags:
        - side-menu
      operationId: getSidemenu
      responses:
        '200':
...
```


**Exception**
```
TypeError: Cannot create property 'responses' on string 'Path to load side menu entries.'
    at stripDefinition (C:\Users\xxxx\AppData\Local\npm-cache\_npx\fb2ea8e0e5441457\node_modules\openapicmd\lib\common\strip-definition.js:179:62)
    at parseDefinition (C:\Users\xxxx\AppData\Local\npm-cache\_npx\fb2ea8e0e5441457\node_modules\openapicmd\lib\common\definition.js:123:59)
    at async Read.run (C:\Users\xxxx\AppData\Local\npm-cache\_npx\fb2ea8e0e5441457\node_modules\openapicmd\lib\commands\read.js:17:24)
    at async Read._run (C:\Users\xxxx\AppData\Local\npm-cache\_npx\fb2ea8e0e5441457\node_modules\@oclif\core\lib\command.js:311:22)
    at async Config.runCommand (C:\Users\xxxx\AppData\Local\npm-cache\_npx\fb2ea8e0e5441457\node_modules\@oclif\core\lib\config\config.js:433:25)
    at async run (C:\Users\xxxx\AppData\Local\npm-cache\_npx\fb2ea8e0e5441457\node_modules\@oclif\core\lib\main.js:92:16)
    at async C:\Users\xxxx\AppData\Local\npm-cache\_npx\fb2ea8e0e5441457\node_modules\openapicmd\bin\run.js:6:3

```