### PR TITLE
fix: escape resource names before using them as type names

### DIFF
--- a/src/typegen/typegen.ts
+++ b/src/typegen/typegen.ts
@@ -241,14 +241,25 @@ function generateMethodForClientOperation(
   return [comment, operationMethod].join('\n');
 }
 
+// generates valid typescript type names.
+// typescript identifiers may contain alphanumeric characters including unicode letters like ä or 漢, digits, underscores, and dollar signs.
+// they may not start with a digit.
+const escapeTypeName = (name: string) => {
+  return name
+    .replace(/\[\]/g, "Array") // handle this special case more semantically
+    .replace(/[^\p{L}\p{N}\$]+/gu, "_") // replace invalid characters with underscores
+    .replace(/^\d+/g, "_"); // replace leading digits with underscores
+}
+
 const generateRootLevelAliases = (exportedTypes: ExportedType[]) => {
   const aliases: string[] = [];
 
   for (const exportedType of exportedTypes) {
     if (exportedType.schemaRef.startsWith('#/components/schemas/')) {
       const name = exportedType.schemaRef.replace('#/components/schemas/', '');
+      const escapedName = escapeTypeName(name);
       aliases.push([
-        `export type ${name} = ${exportedType.path};`,
+        `export type ${escapedName} = ${exportedType.path};`,
       ].join('\n'));
     }
   }


### PR DESCRIPTION
my openapi schema contains the following declaration, this is auto-generated and i don't have control over it:
```json
"ResponseEnvelopeFoo[]": {
    "type": "object",
    "properties": {
        "status": { "type": "string", "enum": ["OK", "ERROR"] },
        "httpCode": { "type": "integer", "format": "int32" },
        "data": {
            "type": "array",
            "items": { "$ref": "#/components/schemas/Foo" }
        },
        "error": { "$ref": "#/components/schemas/ErrorDetails" }
    }
}
```
this gets parsed as this:
```typescript
export type ResponseEnvelopeFoo[] = Components.Schemas.ResponseEnvelopeFoo;
```
which is of course invalid typescript syntax and breaks my build.

this pr fixes this by escaping the names of openapi resources before using them as type names.