### PR TITLE
Fix(#60): Resolve jestCore at runtime & mark it as optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "deepmerge": "^4.3.0",
     "get-port": "^5.0.0",
     "inquirer": "^7.1.0",
-    "jest": "^29.7.0",
-    "jest-json-schema": "^6.1.0",
     "js-yaml": "^4.1.0",
     "klona": "^2.0.6",
     "koa": "^2.14.1",
@@ -44,6 +42,10 @@
     "swagger2openapi": "^7.0.8",
     "tslib": "^2.5.0",
     "yargs": "^17.7.2"
+  },
+  "peerDependencies": {
+    "jest": "^29.7.0",
+    "jest-json-schema": "^6.1.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.10",
@@ -63,6 +65,8 @@
     "chai": "^4.2.0",
     "eslint": "^8.51.0",
     "globby": "^11.0.0",
+    "jest": "^29.7.0",
+    "jest-json-schema": "^6.1.0",
     "nock": "^13.3.0",
     "oclif": "^4.0.2",
     "openapi-types": "^12.1.0",

--- a/src/commands/test/index.ts
+++ b/src/commands/test/index.ts
@@ -1,4 +1,3 @@
-import { runCLI } from '@jest/core';
 import { Document } from '@apidevtools/swagger-parser';
 import type { Config } from '@jest/types';
 import { Command, Flags } from '@oclif/core';
@@ -34,6 +33,17 @@ export class Test extends Command {
   };
 
   public async run() {
+    let jestCore: typeof import('@jest/core');
+    try {
+      jestCore = await import('@jest/core');
+      await import('jest-json-schema');
+    } catch {
+      this.error(
+        'The "openapi test" command requires jest and jest-json-schema to be installed.\nRun: npm install jest jest-json-schema',
+        { exit: 1 },
+      );
+    }
+
     const { args, flags } = await this.parse(Test);
     const { dereference, validate, bundle, header } = flags;
     
@@ -148,6 +158,7 @@ export class Test extends Command {
     setContext((ctx) => ({ ...ctx, flags: { ...ctx.flags, interactive: false } }))
 
     debug('jestArgv', jestArgv);
+    const { runCLI } = jestCore;
     await runCLI(jestArgv, [testProjectDir]);
   }
 }


### PR DESCRIPTION
As a suggestion, this could reduce some of the install size as marked in https://github.com/openapistack/openapicmd/issues/60

Let me know if this is useful; happy to take another stab or approach - the pain is real :)