### PR TITLE
fix(typegen): fix missing params at path level

### DIFF
--- a/__tests__/resources/example-pet-api.openapi.yml
+++ b/__tests__/resources/example-pet-api.openapi.yml
@@ -47,6 +47,13 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/PetPayload'
   '/pets/{id}':
+    parameters:
+      - name: x-tenant-id
+        in: header
+        description: Tenant identifier required for all operations on this path
+        required: true
+        schema:
+          type: string
     get:
       operationId: getPetById
       summary: Get a pet

--- a/src/typegen/typegen.test.ts
+++ b/src/typegen/typegen.test.ts
@@ -53,10 +53,11 @@ describe('generateTypesForDocument', () => {
     });
 
     test('types parameters', () => {
-      expect(clientOperationTypes).toMatch(`parameters: Parameters<Paths.GetPetById.PathParameters>`);
-      expect(clientOperationTypes).toMatch(`parameters: Parameters<Paths.ReplacePetById.PathParameters>`);
-      expect(clientOperationTypes).toMatch(`parameters: Parameters<Paths.UpdatePetById.PathParameters>`);
-      expect(clientOperationTypes).toMatch(`parameters: Parameters<Paths.DeletePetById.PathParameters>`);
+      expect(clientOperationTypes).toMatch(`Paths.Pets$Id.HeaderParameters`);
+      expect(clientOperationTypes).toMatch(`Paths.GetPetById.PathParameters`);
+      expect(clientOperationTypes).toMatch(`Paths.ReplacePetById.PathParameters`);
+      expect(clientOperationTypes).toMatch(`Paths.UpdatePetById.PathParameters`);
+      expect(clientOperationTypes).toMatch(`Paths.DeletePetById.PathParameters`);
       expect(clientOperationTypes).toMatch(`parameters: Parameters<Paths.GetOwnerByPetId.PathParameters>`);
       expect(clientOperationTypes).toMatch(`parameters: Parameters<Paths.GetPetOwner.PathParameters>`);
     });

--- a/src/typegen/typegen.ts
+++ b/src/typegen/typegen.ts
@@ -262,10 +262,19 @@ const normalizeSchema = (schema: Document): Document => {
   // dtsgenerator doesn't generate parameters correctly if they are $refs to Parameter Objects
   // so we resolve them here
   for (const path in clonedSchema.paths ?? {}) {
-    const pathItem = clonedSchema.paths[path];
+    const pathItem = clonedSchema.paths?.[path] ?? {};
+    const pathLevelParameters = pathItem.parameters ?? [];
+
     for (const method in pathItem) {
       const operation = pathItem[method as HttpMethod];
-      if (operation.parameters) {
+      if (operation) {
+        // Merge path-level parameters with operation-level parameters
+        const operationParams = operation.parameters ?? [];
+        operation.parameters = [
+          ...pathLevelParameters,
+          ...operationParams
+        ];
+
         operation.parameters = operation.parameters.map((parameter) => {
           if ('$ref' in parameter) {
             const refPath = parameter.$ref.replace('#/', '').replace(/\//g, '.');


### PR DESCRIPTION
I wish to solve an issue I have with some specs that sets their parameters at the path level instead of the operation level. The path level parameters were not included in the generated types and can't be used in the openapi client